### PR TITLE
Support resetting password for users

### DIFF
--- a/docs/data-sources/profile.md
+++ b/docs/data-sources/profile.md
@@ -3,12 +3,12 @@
 page_title: "salesforce_profile Data Source - terraform-provider-salesforce"
 subcategory: ""
 description: |-
-  
+  Profile Data Source for the Salesforce Provider
 ---
 
 # salesforce_profile (Data Source)
 
-
+Profile Data Source for the Salesforce Provider
 
 ## Example Usage
 

--- a/docs/data-sources/user_license.md
+++ b/docs/data-sources/user_license.md
@@ -3,12 +3,12 @@
 page_title: "salesforce_user_license Data Source - terraform-provider-salesforce"
 subcategory: ""
 description: |-
-  
+  User License Data Source for the Salesforce Provider
 ---
 
 # salesforce_user_license (Data Source)
 
-
+User License Data Source for the Salesforce Provider
 
 ## Example Usage
 

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -3,12 +3,12 @@
 page_title: "salesforce_profile Resource - terraform-provider-salesforce"
 subcategory: ""
 description: |-
-  
+  Profile Resource for the Salesforce Provider
 ---
 
 # salesforce_profile (Resource)
 
-
+Profile Resource for the Salesforce Provider
 
 ## Example Usage
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -52,6 +52,7 @@ resource "salesforce_user" "example" {
 - **email_encoding_key** (String) The email encoding for the user, such as ISO-8859-1 or UTF-8. Defaults to UTF-8.
 - **language_locale_key** (String) The user’s language. Defaults to en_US.
 - **locale_sid_key** (String) The value of the field affects formatting and parsing of values, especially numeric values, in the user interface. It doesn’t affect the API. The field values are named according to the language, and the country if necessary, using two-letter ISO codes. The set of names is based on the ISO standard. You can also manually set a user’s locale in the user interface, and then use that value for inserting or updating other users via the API. Defaults to en_US.
+- **reset_password** (Boolean) Reset password and send an email to the user. No reset is performed if this field is omitted, is false, or was true and remained true on subsequent apply. Please set to false and then true in subsequent applies, or have it set to true on create to trigger the reset.
 - **time_zone_sid_key** (String) A User time zone affects the offset used when displaying or entering times in the user interface. But the API doesn’t use a User time zone when querying or setting values. Values for this field are named using region and key city, according to ISO standards. You can also manually set one User time zone in the user interface, and then use that value for creating or updating other User records via the API. Defaults to America/New_York.
 - **user_role_id** (String) ID of the user’s UserRole.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -3,12 +3,12 @@
 page_title: "salesforce_user Resource - terraform-provider-salesforce"
 subcategory: ""
 description: |-
-  
+  User Resource for the Salesforce Provider
 ---
 
 # salesforce_user (Resource)
 
-
+User Resource for the Salesforce Provider
 
 ## Example Usage
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -33,6 +33,7 @@ resource "salesforce_user" "example" {
   language_locale_key = "en_US"
   time_zone_sid_key   = "America/Chicago"
   locale_sid_key      = "en_US"
+  reset_password      = true
 }
 ```
 

--- a/docs/resources/user_role.md
+++ b/docs/resources/user_role.md
@@ -3,12 +3,12 @@
 page_title: "salesforce_user_role Resource - terraform-provider-salesforce"
 subcategory: ""
 description: |-
-  
+  User Role Resource for the Salesforce Provider
 ---
 
 # salesforce_user_role (Resource)
 
-
+User Role Resource for the Salesforce Provider
 
 ## Example Usage
 

--- a/examples/resources/salesforce_user/resource.tf
+++ b/examples/resources/salesforce_user/resource.tf
@@ -18,4 +18,5 @@ resource "salesforce_user" "example" {
   language_locale_key = "en_US"
   time_zone_sid_key   = "America/Chicago"
   locale_sid_key      = "en_US"
+  reset_password      = true
 }

--- a/internal/provider/data_source_profile.go
+++ b/internal/provider/data_source_profile.go
@@ -16,6 +16,7 @@ type profileDatasourceType struct {
 
 func (profileDatasourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
+		Description: "Profile Data Source for the Salesforce Provider",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
 				Description: "ID of the resource.",

--- a/internal/provider/data_source_user_license.go
+++ b/internal/provider/data_source_user_license.go
@@ -17,6 +17,7 @@ type userLicenseDatasourceType struct {
 
 func (userLicenseDatasourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
+		Description: "User License Data Source for the Salesforce Provider",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
 				Description: "ID of the resource.",

--- a/internal/provider/modifiers.go
+++ b/internal/provider/modifiers.go
@@ -91,3 +91,14 @@ func (fixNullToUnknown) Modify(_ context.Context, req tfsdk.ModifyAttributePlanR
 		resp.AttributePlan = config
 	}
 }
+
+type booleanNilIsFalse struct {
+	emptyDescriptions
+}
+
+func (booleanNilIsFalse) Modify(_ context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
+	resp.AttributePlan = req.AttributePlan
+	if req.AttributeConfig.(types.Bool).Null {
+		resp.AttributePlan = types.Bool{Value: false}
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,6 +24,7 @@ type provider struct {
 
 func (p *provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
+		Description: "A Provider for managing a Salesforce Organization",
 		Attributes: map[string]tfsdk.Attribute{
 			"client_id": {
 				Description: "Client ID of the connected app. Corresponds to Consumer Key in the user interface. Can be specified with the environment variable SALESFORCE_CLIENT_ID.",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -14,4 +15,10 @@ var providerFactories = map[string]func() (tfprotov6.ProviderServer, error){
 }
 
 func testAccPreCheck(t *testing.T) {
+	testEnvVars := []string{"SALESFORCE_CLIENT_ID", "SALESFORCE_PRIVATE_KEY", "SALESFORCE_API_VERSION", "SALESFORCE_USERNAME"}
+	for _, env := range testEnvVars {
+		if os.Getenv(env) == "" {
+			t.Fatalf("%s must be set for acceptance tests", env)
+		}
+	}
 }

--- a/internal/provider/resource_profile.go
+++ b/internal/provider/resource_profile.go
@@ -16,6 +16,7 @@ type profileType struct {
 
 func (profileType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
+		Description: "Profile Resource for the Salesforce Provider",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
 				Description: "ID of the resource.",

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -36,6 +36,7 @@ type userType struct {
 
 func (userType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
+		Description: "User Resource for the Salesforce Provider",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
 				Description: "ID of the resource.",

--- a/internal/provider/resource_user_role.go
+++ b/internal/provider/resource_user_role.go
@@ -14,6 +14,7 @@ type userRoleType struct {
 
 func (userRoleType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
+		Description: "User Role Resource for the Salesforce Provider",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
 				Description: "ID of the resource.",


### PR DESCRIPTION
Password reset can now be controlled with the `reset_password` field. It will only trigger a reset email to the user if going from `false => true`.

Snuck in a few documentation misses and a test precheck.