### PR TITLE
Early Feedback Changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,10 +26,8 @@ SALESFORCE_USERNAME
 If running tests or using the provider against a "Sandbox Org" please be sure to set
 
 ```
-SALESFORCE_IS_SANDBOX_ORG
+SALESFORCE_LOGIN_URL="https://test.salesforce.com"
 ```
-
-To a [Golang truthy value](https://pkg.go.dev/strconv#ParseBool)
 
 The tests and provider assume the profile of the specified `SALESFORCE_USERNAME` has "System Administrator" permissions.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
       env:
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
-        SALESFORCE_API_VERSION: "v53.0"
+        SALESFORCE_API_VERSION: "53.0"
         SALESFORCE_IS_SANDBOX_ORG: "1"
         SALESFORCE_CLIENT_ID: ${{ secrets.SALESFORCE_CLIENT_ID }}
         SALESFORCE_PRIVATE_KEY: ${{ secrets.SALESFORCE_PRIVATE_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
         SALESFORCE_API_VERSION: "53.0"
-        SALESFORCE_IS_SANDBOX_ORG: "1"
+        SALESFORCE_LOGIN_URL: "https://test.salesforce.com"
         SALESFORCE_CLIENT_ID: ${{ secrets.SALESFORCE_CLIENT_ID }}
         SALESFORCE_PRIVATE_KEY: ${{ secrets.SALESFORCE_PRIVATE_KEY }}
         SALESFORCE_USERNAME: ${{ secrets.SALESFORCE_USERNAME }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The Salesforce provider provides resources to interact with a Salesforce organiz
 provider "salesforce" {
   client_id      = "ABCDEFG"
   private_key    = "/Users/mscott/priv.pem"
-  api_version    = "v53.0"
+  api_version    = "53.0"
   username       = "user@example.com"
   is_sandbox_org = false
 }
@@ -71,7 +71,7 @@ SALESFORCE_USERNAME
 
 ### Optional
 
-- **api_version** (String) API version of the salesforce org in the format in the format: vMAJOR.MINOR. The provider requires at least version v53.0. Can be specified with the environment variable SALESFORCE_API_VERSION.
+- **api_version** (String) API version of the salesforce org in the format in the format: MAJOR.MINOR (please omit any leading 'v'). The provider requires at least version 53.0. Can be specified with the environment variable SALESFORCE_API_VERSION.
 - **client_id** (String) Client ID of the connected app. Corresponds to Consumer Key in the user interface. Can be specified with the environment variable SALESFORCE_CLIENT_ID.
 - **is_sandbox_org** (Boolean) Indicates if the salesforce org is a sandbox org or a developer/production org. Ensures the provider attempts to authenticate with the correct server. Can be specified with the environment variable SALESFORCE_IS_SANDBOX_ORG.
 - **private_key** (String, Sensitive) Private Key associated to the public certificate that was uploaded to the connected app. This may point to a file location or be set directly. This should not be confused with the Consumer Secret in the user interface. Can be specified with the environment variable SALESFORCE_PRIVATE_KEY.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,11 +14,10 @@ The Salesforce provider provides resources to interact with a Salesforce organiz
 
 ```terraform
 provider "salesforce" {
-  client_id      = "ABCDEFG"
-  private_key    = "/Users/mscott/priv.pem"
-  api_version    = "53.0"
-  username       = "user@example.com"
-  is_sandbox_org = false
+  client_id   = "ABCDEFG"
+  private_key = "/Users/mscott/priv.pem"
+  api_version = "53.0"
+  username    = "user@example.com"
 }
 ```
 
@@ -73,6 +72,6 @@ SALESFORCE_USERNAME
 
 - **api_version** (String) API version of the salesforce org in the format in the format: MAJOR.MINOR (please omit any leading 'v'). The provider requires at least version 53.0. Can be specified with the environment variable SALESFORCE_API_VERSION.
 - **client_id** (String) Client ID of the connected app. Corresponds to Consumer Key in the user interface. Can be specified with the environment variable SALESFORCE_CLIENT_ID.
-- **is_sandbox_org** (Boolean) Indicates if the salesforce org is a sandbox org or a developer/production org. Ensures the provider attempts to authenticate with the correct server. Can be specified with the environment variable SALESFORCE_IS_SANDBOX_ORG.
+- **login_url** (String) Directs the authentication request, defaults to the production endpoint https://login.salesforce.com, should be set to https://test.salesforce.com for sandbox organizations. Can be specified with the environment variable SALESFORCE_LOGIN_URL.
 - **private_key** (String, Sensitive) Private Key associated to the public certificate that was uploaded to the connected app. This may point to a file location or be set directly. This should not be confused with the Consumer Secret in the user interface. Can be specified with the environment variable SALESFORCE_PRIVATE_KEY.
 - **username** (String) Salesforce Username of a System Administrator like user for the provider to authenticate as. Can be specified with the environment variable SALESFORCE_USERNAME.

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -3,12 +3,12 @@
 page_title: "salesforce_profile Resource - terraform-provider-salesforce"
 subcategory: ""
 description: |-
-  Profile Resource for the Salesforce Provider
+  Profile Resource for the Salesforce Provider. Please note that Users must have a Profile assigned to them, Profiles cannot be deleted if a User is assigned to it, and Salesforce does not allow the deletion of Users, only deactivation. Terraform will warn after destroy of a User that it has only been deactivated and now removed from state. A common issue with this pattern is a Profile and User created in tandem will fail to delete the Profile on destroy due to the lingering assignment. Should you wish to destroy a created Profile, it's advised that an apply that moves all affected Users to a static Profile be run first, after which the Profile can be safely destroyed.
 ---
 
 # salesforce_profile (Resource)
 
-Profile Resource for the Salesforce Provider
+Profile Resource for the Salesforce Provider. Please note that Users must have a Profile assigned to them, Profiles cannot be deleted if a User is assigned to it, and Salesforce does not allow the deletion of Users, only deactivation. Terraform will warn after destroy of a User that it has only been deactivated and now removed from state. A common issue with this pattern is a Profile and User created in tandem will fail to delete the Profile on destroy due to the lingering assignment. Should you wish to destroy a created Profile, it's advised that an apply that moves all affected Users to a static Profile be run first, after which the Profile can be safely destroyed.
 
 ## Example Usage
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,6 @@
 provider "salesforce" {
-  client_id      = "ABCDEFG"
-  private_key    = "/Users/mscott/priv.pem"
-  api_version    = "53.0"
-  username       = "user@example.com"
-  is_sandbox_org = false
+  client_id   = "ABCDEFG"
+  private_key = "/Users/mscott/priv.pem"
+  api_version = "53.0"
+  username    = "user@example.com"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 provider "salesforce" {
   client_id      = "ABCDEFG"
   private_key    = "/Users/mscott/priv.pem"
-  api_version    = "v53.0"
+  api_version    = "53.0"
   username       = "user@example.com"
   is_sandbox_org = false
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v0.4.2
 	github.com/hashicorp/terraform-plugin-go v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nimajalali/go-force v0.0.0-20200831220737-454890ee2b7c
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -96,7 +96,7 @@ type Config struct {
 	PrivateKey string
 	ApiVersion string
 	Username   string
-	Sandbox    bool
+	LoginUrl   string
 }
 
 func Client(config Config) (*force.ForceApi, error) {
@@ -117,17 +117,17 @@ func Client(config Config) (*force.ForceApi, error) {
 		privateKeyBytes = []byte(config.PrivateKey)
 	}
 
-	loginDomain := productionSalesforceLoginServer
-	if config.Sandbox {
-		loginDomain = sandboxSalesforceLoginServer
+	if config.LoginUrl == "" {
+		config.LoginUrl = productionSalesforceLoginServer
 	}
+	config.LoginUrl = strings.TrimSuffix(config.LoginUrl, "/")
 
-	signedJwt, err := SignJWT(privateKeyBytes, config.Username, config.ClientId, loginDomain)
+	signedJwt, err := SignJWT(privateKeyBytes, config.Username, config.ClientId, config.LoginUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := Authenticate(loginDomain, signedJwt)
+	resp, err := Authenticate(config.LoginUrl, signedJwt)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -132,5 +132,9 @@ func Client(config Config) (*force.ForceApi, error) {
 		return nil, err
 	}
 
-	return force.CreateWithAccessToken(config.ApiVersion, config.ClientId, resp.AccessToken, resp.InstanceUrl)
+	apiVersion := config.ApiVersion
+	if !strings.HasPrefix(apiVersion, "v") {
+		apiVersion = "v" + apiVersion
+	}
+	return force.CreateWithAccessToken(apiVersion, config.ClientId, resp.AccessToken, resp.InstanceUrl)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,7 +38,7 @@ func (p *provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Sensitive:   true,
 			},
 			"api_version": {
-				Description: "API version of the salesforce org in the format in the format: vMAJOR.MINOR. The provider requires at least version v53.0. Can be specified with the environment variable SALESFORCE_API_VERSION.",
+				Description: "API version of the salesforce org in the format in the format: MAJOR.MINOR (please omit any leading 'v'). The provider requires at least version 53.0. Can be specified with the environment variable SALESFORCE_API_VERSION.",
 				Type:        types.StringType,
 				Optional:    true,
 			},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -47,9 +46,9 @@ func (p *provider) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics)
 				Type:        types.StringType,
 				Optional:    true,
 			},
-			"is_sandbox_org": {
-				Description: "Indicates if the salesforce org is a sandbox org or a developer/production org. Ensures the provider attempts to authenticate with the correct server. Can be specified with the environment variable SALESFORCE_IS_SANDBOX_ORG.",
-				Type:        types.BoolType,
+			"login_url": {
+				Description: "Directs the authentication request, defaults to the production endpoint https://login.salesforce.com, should be set to https://test.salesforce.com for sandbox organizations. Can be specified with the environment variable SALESFORCE_LOGIN_URL.",
+				Type:        types.StringType,
 				Optional:    true,
 			},
 		},
@@ -61,7 +60,7 @@ type providerData struct {
 	PrivateKey types.String `tfsdk:"private_key"`
 	ApiVersion types.String `tfsdk:"api_version"`
 	Username   types.String `tfsdk:"username"`
-	Sandbox    types.Bool   `tfsdk:"is_sandbox_org"`
+	LoginUrl   types.String `tfsdk:"login_url"`
 }
 
 func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderRequest, resp *tfsdk.ConfigureProviderResponse) {
@@ -88,8 +87,8 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		addCannotInterpolateInProviderBlockError(resp, "username")
 		return
 	}
-	if config.Sandbox.Unknown {
-		addCannotInterpolateInProviderBlockError(resp, "is_sandbox_org")
+	if config.LoginUrl.Unknown {
+		addCannotInterpolateInProviderBlockError(resp, "login_url")
 		return
 	}
 
@@ -106,19 +105,8 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 	if config.Username.Null {
 		config.Username.Value = os.Getenv("SALESFORCE_USERNAME")
 	}
-	if config.Sandbox.Null {
-		if isSandboxStr := os.Getenv("SALESFORCE_IS_SANDBOX_ORG"); isSandboxStr != "" {
-			isSandbox, err := strconv.ParseBool(isSandboxStr)
-			if err != nil {
-				resp.Diagnostics.AddAttributeError(
-					tftypes.NewAttributePath().WithAttributeName("is_sandbox_org"),
-					"Invalid provider config",
-					err.Error(),
-				)
-				return
-			}
-			config.Sandbox.Value = isSandbox
-		}
+	if config.LoginUrl.Null {
+		config.LoginUrl.Value = os.Getenv("SALESFORCE_LOGIN_URL")
 	}
 
 	// required if still unset
@@ -143,7 +131,7 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		Username:   config.Username.Value,
 		ClientId:   config.ClientId.Value,
 		PrivateKey: config.PrivateKey.Value,
-		Sandbox:    config.Sandbox.Value,
+		LoginUrl:   config.LoginUrl.Value,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating salesforce client", err.Error())

--- a/internal/provider/resource_profile.go
+++ b/internal/provider/resource_profile.go
@@ -16,7 +16,7 @@ type profileType struct {
 
 func (profileType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
-		Description: "Profile Resource for the Salesforce Provider",
+		Description: "Profile Resource for the Salesforce Provider. Please note that Users must have a Profile assigned to them, Profiles cannot be deleted if a User is assigned to it, and Salesforce does not allow the deletion of Users, only deactivation. Terraform will warn after destroy of a User that it has only been deactivated and now removed from state. A common issue with this pattern is a Profile and User created in tandem will fail to delete the Profile on destroy due to the lingering assignment. Should you wish to destroy a created Profile, it's advised that an apply that moves all affected Users to a static Profile be run first, after which the Profile can be safely destroyed.",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
 				Description: "ID of the resource.",

--- a/internal/provider/resource_profile.go
+++ b/internal/provider/resource_profile.go
@@ -122,8 +122,11 @@ func (p profileMap) ToStateData(includePermissions ...string) profileResourceDat
 		Name:          p["Name"].(string),
 		UserLicenseId: p["UserLicenseId"].(string),
 	}
-	desc := p["Description"].(string)
-	data.Description = &desc
+	desc, ok := p["Description"]
+	if ok && desc != nil {
+		descStr := desc.(string)
+		data.Description = &descStr
+	}
 	// expand permissions
 	permissions := make(map[string]attr.Value, len(includePermissions))
 	for _, k := range includePermissions {


### PR DESCRIPTION
These changes are based on early feedback from an external review. The changes include:
* Fixing a nil panic
* Switching to a `login_url` field over the `is_sandbox_org` field
* Fixing the passing of a private key directly to the provider
* Encouraging omitting the leading `v` in the api version. (however where the version is used it can still support both scenarios, we will encourage the omission).
* Including a lengthy write up on a common problem you can run into with Users and Profiles on destroy.