### PR TITLE
Necessary bits to onboard project to the Releases API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,20 +30,43 @@ jobs:
           name: release-notes
           path: release-notes.txt
           retention-days: 1
-  terraform-provider-release:
-    name: 'Terraform Provider Release'
-    needs: [go-version, release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v1
-    secrets:
-      hc-releases-aws-access-key-id: '${{ secrets.TF_PROVIDER_RELEASE_AWS_ACCESS_KEY_ID }}'
-      hc-releases-aws-secret-access-key: '${{ secrets.TF_PROVIDER_RELEASE_AWS_SECRET_ACCESS_KEY }}'
-      hc-releases-aws-role-arn: '${{ secrets.TF_PROVIDER_RELEASE_AWS_ROLE_ARN }}'
-      hc-releases-fastly-api-token: '${{ secrets.HASHI_FASTLY_PURGE_TOKEN }}'
-      hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
-      hc-releases-terraform-registry-sync-token: '${{ secrets.TF_PROVIDER_RELEASE_TERRAFORM_REGISTRY_SYNC_TOKEN }}'
-      setup-signore-github-token: '${{ secrets.HASHI_SIGNORE_GITHUB_TOKEN }}'
-      signore-client-id: '${{ secrets.SIGNORE_CLIENT_ID }}'
-      signore-client-secret: '${{ secrets.SIGNORE_CLIENT_SECRET }}'
-    with:
-      release-notes: true
-      setup-go-version: '${{ needs.go-version.outputs.version }}'
+
+      - name: Setup hc-releases
+        uses: hashicorp/actions-setup-hc-releases@v2
+        with:
+          github-token: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
+        
+        terraform-provider-release:
+          name: 'Terraform Provider Release'
+          needs: [go-version, release-notes]
+          uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v1
+          secrets:
+            hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
+            hc-releases-terraform-registry-sync-token: '${{ secrets.TF_PROVIDER_RELEASE_TERRAFORM_REGISTRY_SYNC_TOKEN }}'
+            setup-signore-github-token: '${{ secrets.HASHI_SIGNORE_GITHUB_TOKEN }}'
+            signore-client-id: '${{ secrets.SIGNORE_CLIENT_ID }}'
+            signore-client-secret: '${{ secrets.SIGNORE_CLIENT_SECRET }}'
+          with:
+            release-notes: true
+            setup-go-version: '${{ needs.go-version.outputs.version }}'
+          env:
+            HC_RELEASES_HOST_STAGING: '${{ secrets.HC_RELEASES_HOST_STAGING }}'
+            HC_RELEASES_KEY_STAGING: '${{ secrets.HC_RELEASES_KEY_STAGING }}'
+
+      - name: Create Release metadata
+        uses: hashicorp/actions-hc-releases-create-metadata@v1
+        with:
+          private-tools-token: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
+          product-name: "terraform-provider-salesforce"
+          version: ${{ github.ref_name }}
+          hc-releases-host: ${{ secrets.HC_RELEASES_HOST_STAGING}}
+          hc-releases-key: ${{ secrets.HC_RELEASES_KEY_STAGING }}
+     
+      - name: Promote
+        uses: hashicorp/actions-hc-releases-promote@v1
+        with:
+          product-name: "terraform-provider-salesforce"
+          version: ${{ github.ref_name }}
+          hc-releases-host: ${{ secrets.HC_RELEASES_HOST_PROD }}
+          hc-releases-key: ${{ secrets.HC_RELEASES_KEY_PROD }}
+          hc-releases-source_env_key: ${{ secrets.HC_RELEASES_KEY_STAGING }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,17 +33,18 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 publishers:
-  - name: hc-releases
+  - name: upload
     checksum: true
     extra_files:
       - glob: 'terraform-registry-manifest.json'
         name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
     signature: true
-    cmd: hc-releases upload-file {{ abs .ArtifactPath }}
+    dir: "{{ dir .ArtifactPath }}"
+    cmd: |
+      hc-releases upload -file={{ .ArtifactName }} -product={{ .ProjectName }} -version={{ .Version }}
     env:
-      - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
-      - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
-      - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
+      - HC_RELEASES_HOST={{ .Env.HC_RELEASES_HOST_STAGING }}
+      - HC_RELEASES_KEY={{ .Env.HC_RELEASES_KEY_STAGING }}
 release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'

--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,2 @@
+url_source_repository      = "https://github.com/hashicorp/terraform-provider-salesforce"
+url_license                = "https://github.com/hashicorp/terraform-provider-salesforce/blob/main/LICENSE"


### PR DESCRIPTION
These are the necessary components that `terraform-provider-salesforce` needs to onboard to Releases API.