### PR TITLE
Ensure TypeMap ElemType is set in Profile resource

### DIFF
--- a/internal/provider/resource_profile.go
+++ b/internal/provider/resource_profile.go
@@ -139,9 +139,8 @@ func (p profileMap) ToStateData(includePermissions ...string) profileResourceDat
 			permissions[trimmedKey] = types.Bool{Unknown: true}
 		}
 	}
-	if len(permissions) > 0 {
-		data.Permissions = types.Map{ElemType: types.BoolType, Elems: permissions}
-	}
+	data.Permissions = types.Map{ElemType: types.BoolType, Elems: permissions}
+
 	return data
 }
 


### PR DESCRIPTION
Newer versions of the plugin framework ensures that all aggregate types have an `ElemType` set, previously empty permission in the profile resource would omit setting the `ElemType`.