### PR TITLE
Add CODEOWNERS file to project root

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @hashicorp/terraform-ecosystem-strategic


### PR DESCRIPTION
# Description

As part of standardising repos in HashiCorp, this PR adds a CODEOWNERS file.

Guidance is to reference teams instead of individuals, so the file starts with our team but it can be updated in future as needed.