### PR TITLE
Update test.yml to address node12 deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v3.5.0
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
       with:
         go-version: '1.16'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
 
     - name: Get dependencies
       run: |
@@ -58,13 +58,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v3.5.0
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
       with:
         go-version: '1.16'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2.1.4
+      uses: actions/setup-go@v3.5.0
       with:
         go-version: '1.16'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.3.5
+      uses: actions/checkout@v3.5.2
 
     - name: Get dependencies
       run: |
@@ -58,13 +58,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2.1.4
+      uses: actions/setup-go@v3.5.0
       with:
         go-version: '1.16'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2.3.5
+      uses: actions/checkout@v3.5.2
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-salesforce/issues/130

Updating actions/setup-go and actions/checkout to address this warning:

<img width="1132" alt="Screenshot 2023-05-23 at 10 24 56" src="https://github.com/hashicorp/terraform-provider-salesforce/assets/15078782/becf8c30-5a28-4308-a110-f891e73b6981">

I chose [actions/checkout@v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2) because it's the latest version, and chose [actions/setup-go@v3.5.0](https://github.com/actions/setup-go/releases/tag/v3.5.0) because the latest version v4.0.0 is very new so I thought we could use the previous version before that major version bump.
